### PR TITLE
Changed the database to a dependency for injection to FastAPI

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,12 +1,20 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from mongita import MongitaClientDisk
 from pydantic import BaseModel
 
-client = MongitaClientDisk()
-db = client.db
-todos = db.todos
-
 app = FastAPI()
+
+db_client = MongitaClientDisk()
+db = db_client.db
+
+
+# Dependency
+def get_todos_db():
+    todos = db.todos
+    return todos
+
+
+print(type(get_todos_db()))
 
 
 class ToDoItem(BaseModel):
@@ -21,7 +29,7 @@ async def root():
 
 
 @app.post("/todos", response_model=ToDoItem)
-async def create_todo_item(new_todo: ToDoItem):
+async def create_todo_item(new_todo: ToDoItem, todos=Depends(get_todos_db)):
     if todos.count_documents({"id": new_todo.id}) > 0:
         raise HTTPException(
             status_code=400,

--- a/test_main.py
+++ b/test_main.py
@@ -1,6 +1,24 @@
 from fastapi.testclient import TestClient
+from main import app, get_todos_db, db
 
-from main import app
+
+# Setup: Override dependency during testing
+def setup_module():
+    app.dependency_overrides[get_todos_db] = override_get_todos_db
+
+
+# Teardown: Drop test_todos database after tests have run
+def teardown_module():
+    def drop_test_todos_db() -> None:
+        db.drop_collection("test_todos")
+
+    drop_test_todos_db()
+
+
+def override_get_todos_db():
+    test_todos = db.test_todos
+    return test_todos
+
 
 client = TestClient(app)
 


### PR DESCRIPTION
### Description

FastAPI allows dependency injection which helps make code easier to maintain and test.
The new `get_todos_db()` function is passed as a `Depends` parameter into FastAPI functions, such as create_new_todo, etc.

Testing is now improved by using a dependency override to use a temporary test database instead of the one that would be used normally. This test database is dropped during teardown.

More info: [Dependencies - First Steps - FastAPI](https://fastapi.tiangolo.com/tutorial/dependencies/)

### Checklist:

- [x] All new and existing tests passed.
